### PR TITLE
Disable solid-refresh transform during SSR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -336,7 +336,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
         filename: id,
         sourceFileName: id,
         presets: [[solid, { ...solidOptions, ...(options.solid || {}) }]],
-        plugins: needHmr && !inNodeModules ? [[solidRefresh, { bundler: 'vite' }]] : [],
+        plugins: needHmr && !isSsr && !inNodeModules ? [[solidRefresh, { bundler: 'vite' }]] : [],
         sourceMaps: true,
         // Vite handles sourcemap flattening
         inputSourceMap: false as any,


### PR DESCRIPTION
We don't need the solid-refresh transform during SSR and it could cause issues. Better to disable it. During SSR, the HMR is handled at the module level by Vite itself